### PR TITLE
feat: initialize lifex project

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+out
+.env
+.env.*
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.eslintcache
+# Prisma
+prisma/dev.db
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# LIFEX
+
+Progetto Next.js 14 con Prisma e PostgreSQL.
+
+## Requisiti
+
+- Node.js 18+
+- Database PostgreSQL (Neon)
+
+## Variabili d'ambiente
+
+```
+DATABASE_URL=
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+AUTH_SECRET=
+```
+
+## 1. Setup Database su Neon
+
+1. Registrati su [https://neon.tech](https://neon.tech).
+2. Crea un nuovo progetto (es. regione Francoforte).
+3. Copia la connection string (es. `postgresql://.../neondb?sslmode=require`).
+4. Crea un file `.env.local` con:
+   
+   ```env
+   DATABASE_URL="postgresql://<utente>:<password>@<host>/<db>?sslmode=require"
+   ```
+
+## 2. Installazione e migrazioni locali
+
+```bash
+npm install
+npm run prisma:deploy
+node prisma/seed.js   # popola i 3 piani
+npm run dev
+```
+
+Test locali:
+
+- [http://localhost:3000/api/health](http://localhost:3000/api/health) → `{ ok: true }`
+- [http://localhost:3000/api/plans](http://localhost:3000/api/plans) → JSON piani
+- [http://localhost:3000/plans](http://localhost:3000/plans) → pagina piani
+
+## 3. Deploy su Vercel
+
+1. Importa la repo in Vercel.
+2. Aggiungi `DATABASE_URL` in **Settings → Environment Variables**.
+3. Deploy automatico.
+4. Testa `/api/health`, `/api/plans`, `/plans`.
+
+## 4. Placeholder variabili future
+
+```
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+AUTH_SECRET=
+```
+

--- a/app/api/db-check/route.js
+++ b/app/api/db-check/route.js
@@ -1,0 +1,14 @@
+import prisma from '../../../lib/prisma';
+
+export async function GET() {
+  const [users, wallets, ledgers, membershipPlans] = await Promise.all([
+    prisma.user.count(),
+    prisma.wallet.count(),
+    prisma.ledger.count(),
+    prisma.membershipPlan.count()
+  ]);
+  return Response.json({
+    ok: true,
+    counts: { users, wallets, ledgers, membershipPlans }
+  });
+}

--- a/app/api/health/route.js
+++ b/app/api/health/route.js
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ ok: true });
+}

--- a/app/api/plans/route.js
+++ b/app/api/plans/route.js
@@ -1,0 +1,18 @@
+import prisma from '../../../lib/prisma';
+
+export async function GET() {
+  const plans = await prisma.membershipPlan.findMany({
+    where: { active: true },
+    orderBy: { price: 'asc' }
+  });
+  return Response.json(
+    plans.map((p) => ({
+      id: p.id,
+      code: p.code,
+      name: p.name,
+      description: p.description,
+      price: p.price,
+      currency: p.currency
+    }))
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'LIFEX',
+  description: 'MVP LIFEX'
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="it">
+      <body style={{ fontFamily: 'system-ui, sans-serif', margin: 0, padding: '2rem' }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Benvenuto in LIFEX</h1>
+      <p>La tua piattaforma di esperienze.</p>
+    </main>
+  );
+}

--- a/app/plans/page.js
+++ b/app/plans/page.js
@@ -1,0 +1,23 @@
+async function getPlans() {
+  const base = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+  const res = await fetch(`${base}/api/plans`, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Errore caricamento piani');
+  return res.json();
+}
+
+export default async function PlansPage() {
+  const plans = await getPlans();
+  return (
+    <main>
+      <h1>Piani</h1>
+      <ul>
+        {plans.map((plan) => (
+          <li key={plan.id}>
+            <strong>{plan.name}</strong> – €{(plan.price / 100).toFixed(2)}
+            {plan.description ? ` — ${plan.description}` : ''}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "lifex",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:deploy": "prisma migrate deploy",
+    "seed": "node prisma/seed.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "@prisma/client": "^5.10.2",
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^15.5.3",
+    "prisma": "^5.10.2"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,50 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum LedgerType {
+  credit
+  debit
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  name      String?
+  wallet    Wallet?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Wallet {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @unique
+  balance   Decimal  @default(0) @db.Decimal(18, 6)
+  ledger    Ledger[]
+}
+
+model Ledger {
+  id        String     @id @default(cuid())
+  wallet    Wallet     @relation(fields: [walletId], references: [id])
+  walletId  String
+  amount    Decimal    @db.Decimal(18, 6)
+  type      LedgerType
+  reason    String?
+  createdAt DateTime   @default(now())
+}
+
+model MembershipPlan {
+  id          String  @id @default(cuid())
+  code        String  @unique
+  name        String
+  description String?
+  price       Int
+  currency    String  @default("EUR")
+  active      Boolean @default(true)
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,44 @@
+import prisma from '../lib/prisma.js';
+
+async function main() {
+  const plans = [
+    {
+      code: 'BASE',
+      name: 'BASE',
+      description: 'Commissioni Digital 10% / Experiences 5%',
+      price: 6000
+    },
+    {
+      code: 'ACCESS',
+      name: 'ACCESS',
+      description: 'Boost x2 commissioni digital',
+      price: 12000
+    },
+    {
+      code: 'PRO',
+      name: 'PRO',
+      description: 'Academy avanzata + vantaggi extra',
+      price: 29900
+    }
+  ];
+
+  for (const plan of plans) {
+    await prisma.membershipPlan.upsert({
+      where: { code: plan.code },
+      update: plan,
+      create: plan
+    });
+  }
+}
+
+main()
+  .then(() => {
+    console.log('Seed completato');
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app router project
- add Prisma schema with user, wallet, ledger and membership plans
- implement health, plans and db-check API routes with sample plans page

## Testing
- `npm run lint`
- `npm test`
- `DATABASE_URL="postgresql://localhost:5432/db" npm run prisma:generate` *(fails: Failed to fetch sha256 checksum 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7380be6c8832d8ec828bb37662267