### PR TITLE
feat: add LLX wallet tiers and fee breakdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,28 @@ Formato: `LLX` + anno corrente (YYYY) + 6 cifre estratte dal codice fiscale. Se 
 Nella vista **Membri** è presente il pulsante “Copia mappa codici”: apre una modal con la mappa `oldCode -> newCode` generata in runtime. È possibile copiare il JSON negli appunti per l'esportazione manuale (demo).
 
 ## Wallet (mock)
-Il Conto Interno mostra il saldo disponibile, le entrate/uscite in attesa e il ledger. Le azioni di Deposito, Prelievo e Trasferimento aggiungono movimenti con stato `in_attesa`, validando importi e (per i trasferimenti) il codice destinatario. Nessuna operazione viene persistita: al refresh i dati tornano a quelli di `wallet.json`.
+Il Conto Interno mostra il saldo disponibile in LLX Points, le entrate/uscite in attesa e il ledger. Le azioni di Ricarica, Trasferimento e Cash-out applicano le fee dinamiche in base allo Stato Attività, presentano una distinta costi prima della conferma e registrano movimenti con stato `in_attesa`. Nessuna operazione viene persistita: al refresh i dati tornano a quelli di `wallet.json`.
+
+<!-- LIFEX:EXTRA -->
+## LLX Points & Fee
+- 1 LLX = 1 € (valuta interna, solo UI).
+- Fee ricarica: 10% (Base), 8% (Access), 1% (Royal).
+- Spostamenti interni: 2% / 1% / 0% (Base/Access/Royal).
+- Cash-out: 5% (<500 LLX), 2% (500–999 LLX), 0% (≥1000 LLX).
+- Premio saldo positivo: se la streak positiva ≥ 30 giorni → cash-out gratuito (0%). (Mock, calcolo client)
+
+## Stati Attività (in base al saldo disponibile)
+- Base: 0–499 LLX
+- Access: 500–999 LLX
+- Royal: ≥ 1000 LLX
+
+## Distinta operazioni
+- Tutte le operazioni mostrano anteprima costi, fee e saldo risultante prima della conferma.
+- Ledger registra importo, fee, stato “in_attesa” (mock).
 
 ## TODO Backend
-- Persistenza dei codici cliente generati e sincronizzazione con l'albero.
-- API per checkout/catalogo e conferma degli ordini.
-- Endpoint per registrare movimenti wallet (depositi/prelievi/transfer) e aggiornare i saldi reali.
-- Gestione posizionamento albero con slot e vincoli reali.
+- Persistenza ledger e saldo, verifica streak reale, esecuzione cash-out/transfer, PDF distinta.
 
 ## Changelog UI
 - aggiunti network/catalog/wallet; generator codici cliente
+- aggiunto Wallet LLX Points, fee dinamiche, distinta costi, stati attività

--- a/lifex-ui/src/data/wallet.json
+++ b/lifex-ui/src/data/wallet.json
@@ -1,5 +1,6 @@
 {
   "balanceEUR": 3245.50,
+  "streakPositiveDays": 42,
   "ledger": [
     {"id":"L-001","when":"2025-09-10T10:00:00Z","type":"deposit","desc":"Deposito iniziale","amountEUR":1000,"status":"completato"},
     {"id":"L-002","when":"2025-09-12T14:30:00Z","type":"bonus","desc":"Bonus generazione 1","amountEUR":345.50,"status":"completato"},

--- a/lifex-ui/src/styles.css
+++ b/lifex-ui/src/styles.css
@@ -78,11 +78,21 @@ a:hover { text-decoration: underline; }
 .badge.warn { background: var(--llx-warn); color: #fff; }
 .badge.err { background: var(--llx-err); color: #fff; }
 .badge.gold { background: var(--llx-gold); color: #000; }
+.badge.tier-base { background: #3b3b3b; color: #fff; }
+.badge.tier-access { background: #3949ab; color: #fff; }
+.badge.tier-royal { background: var(--llx-gold); color: #000; font-weight: 600; }
+.badge.ledger-type { background: var(--llx-surface-alt); color: var(--llx-text); font-weight: 600; }
+
+.promo-badge { font-size: 0.75rem; padding: 2px 8px; border-radius: var(--llx-radius); display: inline-flex; align-items: center; gap: var(--llx-space-xs); }
 
 .btn { padding: var(--llx-space-s) var(--llx-space-m); border-radius: var(--llx-radius); border:1px solid var(--llx-border); cursor:pointer; background: var(--llx-surface-alt); color: var(--llx-text); }
 .btn.gold { background: var(--llx-gold); color: #000; border-color: var(--llx-gold); }
 .btn.ghost { background: transparent; }
 .btn[disabled] { opacity:0.5; cursor:not-allowed; }
+
+.btn-action { display:flex; flex-direction:column; align-items:flex-start; gap:var(--llx-space-xs); text-align:left; min-width:160px; }
+.btn-action .btn-title { font-weight:600; }
+.btn-action .btn-subtitle { font-size:0.75rem; color:var(--llx-text-muted); text-transform:uppercase; letter-spacing:0.08em; }
 
 .input { background: var(--llx-surface); border:1px solid var(--llx-border); color: var(--llx-text); padding: var(--llx-space-s); border-radius: var(--llx-radius); }
 
@@ -100,6 +110,10 @@ a:hover { text-decoration: underline; }
 .hidden { display:none !important; }
 
 .muted { color: var(--llx-text-muted); }
+
+.llx { font-variant-numeric: tabular-nums; display:inline-flex; align-items:center; gap:var(--llx-space-xs); }
+.llx.positive { color: var(--green-500); }
+.llx.negative { color: var(--red-500); }
 
 .banner { padding: var(--llx-space-s) var(--llx-space-m); border-radius: var(--llx-radius); border: 1px solid var(--llx-border); font-size: 0.9rem; }
 .banner.info { background: rgba(212, 175, 55, 0.1); color: var(--llx-gold); border-color: var(--llx-gold); }
@@ -134,14 +148,41 @@ a:hover { text-decoration: underline; }
 .product-card .tags { display:flex; flex-wrap:wrap; gap:var(--llx-space-xs); }
 
 .wallet-card { display:flex; flex-direction:column; gap:var(--llx-space-m); }
-.wallet-card .wallet-balance { font-size:2rem; font-weight:600; color:var(--llx-gold); }
-.wallet-card .wallet-breakdown { display:grid; gap:var(--llx-space-s); grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); }
+.wallet-card-header { display:flex; flex-wrap:wrap; justify-content:space-between; gap:var(--llx-space-m); align-items:flex-start; }
+.wallet-card-main { display:flex; flex-direction:column; gap:var(--llx-space-xs); }
+.wallet-card .wallet-balance { display:flex; flex-direction:column; gap:var(--llx-space-xs); }
+.wallet-card .wallet-balance .llx { font-size:2rem; font-weight:600; color:var(--llx-gold); }
+.wallet-card .wallet-balance .eur { font-size:1rem; color:var(--llx-text-muted); }
+.wallet-card .micro-copy { font-size:0.8rem; color:var(--llx-text-muted); }
+.wallet-card-activity { display:flex; flex-direction:column; gap:var(--llx-space-s); max-width:260px; }
+.wallet-card-activity .label { font-size:0.75rem; text-transform:uppercase; letter-spacing:0.08em; color:var(--llx-text-muted); }
+.wallet-card-activity .activity-copy { font-size:0.8rem; line-height:1.4; }
+.wallet-card .wallet-breakdown { display:grid; gap:var(--llx-space-s); grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
 .wallet-card .wallet-breakdown div { display:flex; flex-direction:column; gap:var(--llx-space-xs); font-size:0.85rem; }
+.wallet-card .wallet-breakdown strong { display:flex; align-items:center; gap:var(--llx-space-xs); font-weight:600; }
+.wallet-card .wallet-breakdown .eur { font-size:0.85rem; color:var(--llx-text-muted); }
+.activity-progress { display:flex; flex-direction:column; gap:var(--llx-space-s); }
+.activity-progress .progress-header { display:flex; flex-wrap:wrap; gap:var(--llx-space-s); justify-content:space-between; align-items:center; }
+.activity-progress .progress-label { font-size:0.9rem; }
+.activity-progress .progress-bar { position:relative; height:8px; background:var(--llx-surface-alt); border-radius:999px; overflow:hidden; }
+.activity-progress .progress-bar span { display:block; height:100%; background:var(--llx-gold); }
+.activity-progress .progress-meta { font-size:0.75rem; color:var(--llx-text-muted); }
 
 .ledger .amount.positive { color: var(--green-500); }
 .ledger .amount.negative { color: var(--red-500); }
+.ledger td.amount { text-align:right; }
 
 .tooltip { border:1px solid var(--llx-gold); background:transparent; color:var(--llx-gold); width:32px; height:32px; border-radius:50%; display:flex; align-items:center; justify-content:center; cursor:help; }
+
+.distinta { margin-top:var(--llx-space-m); padding:var(--llx-space-m); border:1px solid var(--llx-border); border-radius:var(--llx-radius); background:var(--llx-surface-alt); display:flex; flex-direction:column; gap:var(--llx-space-m); }
+.distinta h4 { margin:0; font-size:1rem; }
+.distinta-list { list-style:none; display:grid; gap:var(--llx-space-s); grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
+.distinta-list li { display:flex; flex-direction:column; gap:var(--llx-space-xs); }
+.distinta-list li span { font-size:0.75rem; letter-spacing:0.05em; text-transform:uppercase; color:var(--llx-text-muted); }
+.distinta-list li strong { font-size:1rem; }
+.distinta-list li em { font-style:normal; font-size:0.75rem; color:var(--llx-text-muted); }
+.distinta.final { border-color: var(--llx-gold); box-shadow:0 0 0 1px rgba(212,175,55,0.25); }
+.distinta .success { color: var(--llx-gold); font-size:0.85rem; }
 
 .toast-container { position: fixed; top: 72px; right: 24px; display:flex; flex-direction:column; gap:var(--llx-space-s); z-index:3000; }
 .toast { background: var(--llx-surface); border:1px solid var(--llx-border); border-left:4px solid var(--llx-gold); padding:var(--llx-space-s) var(--llx-space-m); border-radius: var(--llx-radius); box-shadow: var(--llx-shadow); }

--- a/lifex-ui/src/views/wallet.html
+++ b/lifex-ui/src/views/wallet.html
@@ -2,9 +2,17 @@
   <div class="toolbar" style="display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:var(--llx-space-m);">
     <h1>Conto Interno</h1>
     <div class="actions" style="display:flex;flex-wrap:wrap;gap:var(--llx-space-s);">
-      <button id="wallet-deposit" class="btn gold">Deposita</button>
-      <button id="wallet-withdraw" class="btn ghost">Preleva</button>
-      <button id="wallet-transfer" class="btn ghost">Trasferisci</button>
+      <button id="wallet-deposit" class="btn gold btn-action">
+        <span class="btn-title">Ricarica LLX</span>
+        <span class="btn-subtitle">Deposita</span>
+      </button>
+      <button id="wallet-transfer" class="btn ghost btn-action">
+        <span class="btn-title">Trasferisci LLX</span>
+      </button>
+      <button id="wallet-cashout" class="btn ghost btn-action">
+        <span class="btn-title">Cash-out</span>
+        <span class="btn-subtitle">Preleva</span>
+      </button>
     </div>
   </div>
   <p class="muted" style="color:var(--llx-text-muted);margin:var(--llx-space-s) 0 var(--llx-space-m);">Operazioni simulate lato client: nessun movimento reale viene inviato.</p>


### PR DESCRIPTION
## Summary
- add LLX Points activity tiers, wallet card badge, and progress display with updated ledger formatting
- implement dynamic modal previews for deposit, transfer, and cash-out operations with fee and balance breakdowns
- refresh styles, wallet buttons, seed data, and README docs to describe LLX fee rules and activity states

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c87f86e674832d968933cad39d4907